### PR TITLE
Enable middle mouse button on embedded platform

### DIFF
--- a/xbmc/input/linux/LinuxInputDevices.cpp
+++ b/xbmc/input/linux/LinuxInputDevices.cpp
@@ -509,7 +509,7 @@ bool CLinuxInputDevice::KeyEvent(const struct input_event& levt, XBMC_Event& dev
         break;
 
       case BTN_MIDDLE:
-        devt.button.button = XBMC_BUTTON_RIGHT;
+        devt.button.button = XBMC_BUTTON_MIDDLE;
         break;
 
       case BTN_FORWARD:


### PR DESCRIPTION
Right now a mouse middle button click triggers a XBMC right click, not a XBMC middle click.

## Description
Changed:

>case BTN_MIDDLE:
>        devt.button.button = XBMC_BUTTON_RIGHT;
>        break;

to

>case BTN_MIDDLE:
>       devt.button.button = XBMC_BUTTON_MIDDLE;
>        break;

so a BTN_MIDDLE is mapped to XBMC_BUTTON_MIDDLE


## Motivation and Context
I use the BTN_MIDDLE event on the Raspberry Pi with a Griffin Powermate USB (dial + push button), emulating a mouse wheel with a middle button.

## How Has This Been Tested?
Patched Libreelec 8.0.1 and tested on a Raspberry Pi.

## Screenshots (if appropriate):

## Types of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
